### PR TITLE
Feature/replace module directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
-module github.com/OSS-Keepers/recipetool-go-test/tree/feature/hello-world-program
+module github.com/OSS-Keepers/recipetool-go-test
 
 go 1.18
 
-require github.com/godbus/dbus/v5 v5.1.0
+replace github.com/matryer/is => ./is
+
+require (
+	github.com/godbus/dbus/v5 v5.1.0
+	github.com/matryer/is v1.4.1
+)

--- a/helloworld.go
+++ b/helloworld.go
@@ -3,10 +3,30 @@ package main
 import (
     "fmt"
     "os"
+    "testing"
 
+    "github.com/matryer/is"
     "github.com/godbus/dbus/v5"
 )
 
 func main() {
+    // dbus and os dependency usage
+    conn, err := dbus.ConnectSessionBus()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "Failed to connect to session bus:", err)
+        os.Exit(1)
+    }
+    defer conn.Close()
+
+    // print hello world
     fmt.Println("Hello World!")
-} 
+}
+
+// "is" dependency usage
+func TestExample(t *testing.T) {
+    is := is.New(t)
+
+    is.True(true) // This test passes
+    is.Equal(1, 1) // This test passes
+    is.NoErr(nil) // No error
+}

--- a/is/LICENSE
+++ b/is/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2018 Mat Ryer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/is/README.md
+++ b/is/README.md
@@ -1,0 +1,39 @@
+# is [![GoDoc](https://godoc.org/github.com/matryer/is?status.png)](http://godoc.org/github.com/matryer/is) [![Go Report Card](https://goreportcard.com/badge/github.com/matryer/is)](https://goreportcard.com/report/github.com/matryer/is)
+Professional lightweight testing mini-framework for Go.
+
+* Easy to write and read
+* [Beautifully simple API](https://pkg.go.dev/github.com/matryer/is) with everything you need: `is.Equal`, `is.True`, `is.NoErr`, and `is.Fail`
+* Use comments to add descriptions (which show up when tests fail)
+
+Failures are very easy to read:
+
+![Examples of failures](https://github.com/matryer/is/raw/master/misc/delicious-failures.png)
+
+### Usage
+
+The following code shows a range of useful ways you can use
+the helper methods:
+
+```go
+func Test(t *testing.T) {
+	is := is.New(t)
+	signedin, err := isSignedIn(ctx)
+	is.NoErr(err)            // isSignedIn error
+	is.Equal(signedin, true) // must be signed in
+	body := readBody(r)
+	is.True(strings.Contains(body, "Hi there"))
+}
+```
+
+## Color
+
+To turn off the colors, run `go test` with the `-nocolor` flag,
+or with the env var [`NO_COLOR` (with any value)](https://no-color.org).
+
+```
+go test -nocolor
+```
+
+```
+NO_COLOR=1 go test
+```

--- a/is/go.mod
+++ b/is/go.mod
@@ -1,0 +1,3 @@
+module github.com/matryer/is
+
+go 1.14

--- a/is/is-1.7.go
+++ b/is/is-1.7.go
@@ -1,0 +1,65 @@
+//go:build go1.7
+// +build go1.7
+
+package is
+
+import (
+	"regexp"
+	"runtime"
+)
+
+// Helper marks the calling function as a test helper function.
+// When printing file and line information, that function will be skipped.
+//
+// Available with Go 1.7 and later.
+func (is *I) Helper() {
+	is.helpers[callerName(1)] = struct{}{}
+}
+
+// callerName gives the function name (qualified with a package path)
+// for the caller after skip frames (where 0 means the current function).
+func callerName(skip int) string {
+	// Make room for the skip PC.
+	var pc [1]uintptr
+	n := runtime.Callers(skip+2, pc[:]) // skip + runtime.Callers + callerName
+	if n == 0 {
+		panic("is: zero callers found")
+	}
+	frames := runtime.CallersFrames(pc[:n])
+	frame, _ := frames.Next()
+	return frame.Function
+}
+
+// The maximum number of stack frames to go through when skipping helper functions for
+// the purpose of decorating log messages.
+const maxStackLen = 50
+
+var reIsSourceFile = regexp.MustCompile(`is(-1.7)?\.go$`)
+
+func (is *I) callerinfo() (path string, line int, ok bool) {
+	var pc [maxStackLen]uintptr
+	// Skip two extra frames to account for this function
+	// and runtime.Callers itself.
+	n := runtime.Callers(2, pc[:])
+	if n == 0 {
+		panic("is: zero callers found")
+	}
+	frames := runtime.CallersFrames(pc[:n])
+	var firstFrame, frame runtime.Frame
+	for more := true; more; {
+		frame, more = frames.Next()
+		if reIsSourceFile.MatchString(frame.File) {
+			continue
+		}
+		if firstFrame.PC == 0 {
+			firstFrame = frame
+		}
+		if _, ok := is.helpers[frame.Function]; ok {
+			// Frame is inside a helper function.
+			continue
+		}
+		return frame.File, frame.Line, true
+	}
+	// If no "non-helper" frame is found, the first non is frame is returned.
+	return firstFrame.File, firstFrame.Line, true
+}

--- a/is/is-1.7_test.go
+++ b/is/is-1.7_test.go
@@ -1,0 +1,54 @@
+//go:build go1.7
+// +build go1.7
+
+package is
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestSubtests ensures subtests work as expected.
+// https://github.com/matryer/is/issues/1
+func TestSubtests(t *testing.T) {
+	t.Run("sub1", func(t *testing.T) {
+		is := New(t)
+		is.Equal(1+1, 2)
+	})
+}
+
+func TestHelper(t *testing.T) {
+	tests := []struct {
+		name             string
+		helper           bool
+		expectedFilename string
+	}{
+		{
+			name:             "without helper",
+			helper:           false,
+			expectedFilename: "is_helper_test.go",
+		},
+		{
+			name:             "with helper",
+			helper:           true,
+			expectedFilename: "is-1.7_test.go",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tt := &mockT{}
+			is := NewRelaxed(tt)
+
+			var buf bytes.Buffer
+			is.out = &buf
+			helper(is, tc.helper)
+			actual := buf.String()
+			t.Log(actual)
+			if !strings.Contains(actual, tc.expectedFilename) {
+				t.Errorf("string does not contain correct filename: %s", actual)
+			}
+		})
+	}
+}

--- a/is/is.go
+++ b/is/is.go
@@ -1,0 +1,403 @@
+// Package is provides a lightweight extension to the
+// standard library's testing capabilities.
+//
+// Comments on the assertion lines are used to add
+// a description.
+//
+// The following failing test:
+//
+//	func Test(t *testing.T) {
+//		is := is.New(t)
+//		a, b := 1, 2
+//		is.Equal(a, b) // expect to be the same
+//	}
+//
+// Will output:
+//
+//	your_test.go:123: 1 != 2 // expect to be the same
+//
+// # Usage
+//
+// The following code shows a range of useful ways you can use
+// the helper methods:
+//
+//	func Test(t *testing.T) {
+//		// always start tests with this
+//		is := is.New(t)
+//
+//		signedin, err := isSignedIn(ctx)
+//		is.NoErr(err)            // isSignedIn error
+//		is.Equal(signedin, true) // must be signed in
+//
+//		body := readBody(r)
+//		is.True(strings.Contains(body, "Hi there"))
+//	}
+package is
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// T reports when failures occur.
+// testing.T implements this interface.
+type T interface {
+	// Fail indicates that the test has failed but
+	// allowed execution to continue.
+	// Fail is called in relaxed mode (via NewRelaxed).
+	Fail()
+	// FailNow indicates that the test has failed and
+	// aborts the test.
+	// FailNow is called in strict mode (via New).
+	FailNow()
+}
+
+// I is the test helper harness.
+type I struct {
+	t        T
+	fail     func()
+	out      io.Writer
+	colorful bool
+
+	helpers map[string]struct{} // functions to be skipped when writing file/line info
+}
+
+var noColorFlag bool
+
+func init() {
+	var envNoColor bool
+
+	// prefer https://no-color.org (with any value)
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		envNoColor = true
+	}
+
+	if v, ok := os.LookupEnv("IS_NO_COLOR"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			envNoColor = b
+		}
+	}
+
+	flag.BoolVar(&noColorFlag, "nocolor", envNoColor, "turns off colors")
+}
+
+// New makes a new testing helper using the specified
+// T through which failures will be reported.
+// In strict mode, failures call T.FailNow causing the test
+// to be aborted. See NewRelaxed for alternative behavior.
+func New(t T) *I {
+	return &I{t, t.FailNow, os.Stdout, !noColorFlag, map[string]struct{}{}}
+}
+
+// NewRelaxed makes a new testing helper using the specified
+// T through which failures will be reported.
+// In relaxed mode, failures call T.Fail allowing
+// multiple failures per test.
+func NewRelaxed(t T) *I {
+	return &I{t, t.Fail, os.Stdout, !noColorFlag, map[string]struct{}{}}
+}
+
+func (is *I) log(args ...interface{}) {
+	s := is.decorate(fmt.Sprint(args...))
+	fmt.Fprintf(is.out, s)
+	is.fail()
+}
+
+func (is *I) logf(format string, args ...interface{}) {
+	is.log(fmt.Sprintf(format, args...))
+}
+
+// Fail immediately fails the test.
+//
+//	func Test(t *testing.T) {
+//		is := is.New(t)
+//		is.Fail() // TODO: write this test
+//	}
+//
+// In relaxed mode, execution will continue after a call to
+// Fail, but that test will still fail.
+func (is *I) Fail() {
+	is.log("failed")
+}
+
+// True asserts that the expression is true. The expression
+// code itself will be reported if the assertion fails.
+//
+//	func Test(t *testing.T) {
+//		is := is.New(t)
+//		val := method()
+//		is.True(val != nil) // val should never be nil
+//	}
+//
+// Will output:
+//
+//	your_test.go:123: not true: val != nil
+func (is *I) True(expression bool) {
+	if !expression {
+		is.log("not true: $ARGS")
+	}
+}
+
+// Equal asserts that a and b are equal.
+//
+//	func Test(t *testing.T) {
+//		is := is.New(t)
+//		a := greet("Mat")
+//		is.Equal(a, "Hi Mat") // greeting
+//	}
+//
+// Will output:
+//
+//	your_test.go:123: Hey Mat != Hi Mat // greeting
+func (is *I) Equal(a, b interface{}) {
+	if areEqual(a, b) {
+		return
+	}
+	if isNil(a) || isNil(b) {
+		is.logf("%s != %s", is.valWithType(a), is.valWithType(b))
+	} else if reflect.ValueOf(a).Type() == reflect.ValueOf(b).Type() {
+		is.logf("%v != %v", a, b)
+	} else {
+		is.logf("%s != %s", is.valWithType(a), is.valWithType(b))
+	}
+}
+
+// New is a method wrapper around the New function.
+// It allows you to write subtests using a similar
+// pattern:
+//
+//	func Test(t *testing.T) {
+//		is := is.New(t)
+//		t.Run("sub", func(t *testing.T) {
+//			is := is.New(t)
+//			// TODO: test
+//		})
+//	}
+func (is *I) New(t T) *I {
+	return New(t)
+}
+
+// NewRelaxed is a method wrapper around the NewRelaxed
+// method. It allows you to write subtests using a similar
+// pattern:
+//
+//	func Test(t *testing.T) {
+//		is := is.NewRelaxed(t)
+//		t.Run("sub", func(t *testing.T) {
+//			is := is.NewRelaxed(t)
+//			// TODO: test
+//		})
+//	}
+func (is *I) NewRelaxed(t T) *I {
+	return NewRelaxed(t)
+}
+
+func (is *I) valWithType(v interface{}) string {
+	if isNil(v) {
+		return "<nil>"
+	}
+	if is.colorful {
+		return fmt.Sprintf("%[1]s%[3]T(%[2]s%[3]v%[1]s)%[2]s", colorType, colorNormal, v)
+	}
+	return fmt.Sprintf("%[1]T(%[1]v)", v)
+}
+
+// NoErr asserts that err is nil.
+//
+//	func Test(t *testing.T) {
+//		is := is.New(t)
+//		val, err := getVal()
+//		is.NoErr(err)        // getVal error
+//		is.True(len(val) > 10) // val cannot be short
+//	}
+//
+// Will output:
+//
+//	your_test.go:123: err: not found // getVal error
+func (is *I) NoErr(err error) {
+	if err != nil {
+		is.logf("err: %s", err.Error())
+	}
+}
+
+// isNil gets whether the object is nil or not.
+func isNil(object interface{}) bool {
+	if object == nil {
+		return true
+	}
+	value := reflect.ValueOf(object)
+	kind := value.Kind()
+	if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
+		return true
+	}
+	return false
+}
+
+// areEqual gets whether a equals b or not.
+func areEqual(a, b interface{}) bool {
+	if isNil(a) && isNil(b) {
+		return true
+	}
+	if isNil(a) || isNil(b) {
+		return false
+	}
+	if reflect.DeepEqual(a, b) {
+		return true
+	}
+	aValue := reflect.ValueOf(a)
+	bValue := reflect.ValueOf(b)
+	return aValue == bValue
+}
+
+// loadComment gets the Go comment from the specified line
+// in the specified file.
+func loadComment(path string, line int) (string, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	i := 1
+	for s.Scan() {
+		if i != line {
+			i++
+			continue
+		}
+
+		text := s.Text()
+		commentI := strings.Index(text, "// ")
+		if commentI == -1 {
+			return "", false // no comment
+		}
+		text = text[commentI+2:]
+		text = strings.TrimSpace(text)
+		return text, true
+	}
+	return "", false
+}
+
+// loadArguments gets the arguments from the function call
+// on the specified line of the file.
+func loadArguments(path string, line int) (string, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	i := 1
+	for s.Scan() {
+		if i != line {
+			i++
+			continue
+		}
+		text := s.Text()
+		braceI := strings.Index(text, "(")
+		if braceI == -1 {
+			return "", false
+		}
+		text = text[braceI+1:]
+		cs := bufio.NewScanner(strings.NewReader(text))
+		cs.Split(bufio.ScanBytes)
+		j := 0
+		c := 1
+		for cs.Scan() {
+			switch cs.Text() {
+			case ")":
+				c--
+			case "(":
+				c++
+			}
+			if c == 0 {
+				break
+			}
+			j++
+		}
+		text = text[:j]
+		return text, true
+	}
+	return "", false
+}
+
+// decorate prefixes the string with the file and line of the call site
+// and inserts the final newline if needed and indentation tabs for formatting.
+// this function was copied from the testing framework and modified.
+func (is *I) decorate(s string) string {
+	path, lineNumber, ok := is.callerinfo() // decorate + log + public function.
+	file := filepath.Base(path)
+	if ok {
+		// Truncate file name at last file name separator.
+		if index := strings.LastIndex(file, "/"); index >= 0 {
+			file = file[index+1:]
+		} else if index = strings.LastIndex(file, "\\"); index >= 0 {
+			file = file[index+1:]
+		}
+	} else {
+		file = "???"
+		lineNumber = 1
+	}
+	buf := new(bytes.Buffer)
+	// Every line is indented at least one tab.
+	buf.WriteByte('\t')
+	if is.colorful {
+		buf.WriteString(colorFile)
+	}
+	fmt.Fprintf(buf, "%s:%d: ", file, lineNumber)
+	if is.colorful {
+		buf.WriteString(colorNormal)
+	}
+
+	s = escapeFormatString(s)
+
+	lines := strings.Split(s, "\n")
+	if l := len(lines); l > 1 && lines[l-1] == "" {
+		lines = lines[:l-1]
+	}
+	for i, line := range lines {
+		if i > 0 {
+			// Second and subsequent lines are indented an extra tab.
+			buf.WriteString("\n\t\t")
+		}
+		// expand arguments (if $ARGS is present)
+		if strings.Contains(line, "$ARGS") {
+			args, _ := loadArguments(path, lineNumber)
+			line = strings.Replace(line, "$ARGS", args, -1)
+		}
+		buf.WriteString(line)
+	}
+	comment, ok := loadComment(path, lineNumber)
+	if ok {
+		if is.colorful {
+			buf.WriteString(colorComment)
+		}
+		buf.WriteString(" // ")
+		comment = escapeFormatString(comment)
+		buf.WriteString(comment)
+		if is.colorful {
+			buf.WriteString(colorNormal)
+		}
+	}
+	buf.WriteString("\n")
+	return buf.String()
+}
+
+// escapeFormatString escapes strings for use in formatted functions like Sprintf.
+func escapeFormatString(fmt string) string {
+	return strings.Replace(fmt, "%", "%%", -1)
+}
+
+const (
+	colorNormal  = "\u001b[00m"
+	colorComment = "\u001b[31m"
+	colorFile    = "\u001b[02m"
+	colorType    = "\u001b[02m"
+)


### PR DESCRIPTION
Add the replacement module test with the smaller version of the "is" library at https://github.com/matryer/is

Here is the result of the recipetool command:

![image](https://github.com/user-attachments/assets/a87940c1-d602-4e73-9d11-2dcae7f3c8dd)

the modules.txt file from recipetools produced the following:

![image](https://github.com/user-attachments/assets/9204d841-337b-4d43-b921-90846bb7d56e)
 
directive modules and licenses look like this:

![image](https://github.com/user-attachments/assets/231d5368-efab-453a-a4d4-f86aac42554c)
