### PR TITLE
feat: Use yocto repository inside module.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/OSS-Keepers/recipetool-go-test
+module git.yoctoproject.org/recipetool-go-test
 
 go 1.18
 


### PR DESCRIPTION
Use the yocto repository under git.yoctoproject.org for the go module.